### PR TITLE
Adding edge weights to XML output

### DIFF
--- a/lib/gexf/edge.rb
+++ b/lib/gexf/edge.rb
@@ -57,6 +57,7 @@ class GEXF::Edge
   def to_hash
     optional = {}
     optional[:label] = label if label && !label.empty?
+    optional[:weight] = weight if weight
 
     {:id => id,
      :source => source_id,


### PR DESCRIPTION
The weight of an edge should be specified as an attribute of the XML edge node, not in a nested custom attribute, i.e. it should look as follows:

```
<edge id="133" source="1" target="66" type="undirected" weight="11.0"/>
```

This change adds the edge weight to the edge's hash, which results in the desired output.
