### PR TITLE
fix symbolize_keys conflict with rails

### DIFF
--- a/lib/gexf/document.rb
+++ b/lib/gexf/document.rb
@@ -72,7 +72,7 @@ private
 
    def sanitize_attrs(attributes)
      Hash[*attributes.flatten].
-       symbolize_keys.
+       symbolize_keys_for_gexf.
        symbolize_graph_types
    end
 

--- a/lib/gexf/support.rb
+++ b/lib/gexf/support.rb
@@ -4,7 +4,7 @@ GEXF::GRAPH_TYPES = (GEXF::Attribute::TYPES   +
                      GEXF::Graph::MODES).uniq
 
 class Hash
-  def symbolize_keys
+  def symbolize_keys_for_gexf
     hash = {}
     each { |k,v| hash[k.to_sym] = delete(k) }
     merge(hash)


### PR DESCRIPTION
The symbolize_keys function in support.rb will overwrite the symbolize_keys function in rails when included to Gemfile.
This function deletes original elements, which will cause errors when rails reading database config files.

So I  change the function's name from "symbolize_keys" to "symbolize_keys_for_gexf" to avoid this problem.
